### PR TITLE
[FIX] Clean erratic targets recipes on .PHONY.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build unit-tests lint codestyle clean open verify sign
+.PHONY: build unit-tests lint codestyle clean
 
 build:
 	@docker-compose up --build --no-start


### PR DESCRIPTION
# PR Details

Remove open, verify, and sign recipe targets from `.PHONY`.
