### PR TITLE
fix: add entrypoints to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,12 @@ setup(
     url="https://github.com/Farfetch/notarizer.git",
     license="MIT License (MIT)",
     include_package_data=True,
-    packages=find_packages(exclude=["notarizer/test"]),
+    packages=find_packages(exclude=["notarizer/test"]),    
+    entry_points={
+        'console_scripts': [
+            'notarizer = notarizer.cli:main'
+        ]
+    },
     setup_requires=setup_requirements,
     install_requires=open('requirements.txt').read().splitlines(),
     author="Farfetch",


### PR DESCRIPTION
# PR Details

Add missing entrypoints to setup.py in order to use notarizer as:

```bash
notarizer -i "image_name:image_tag" -p "public-key.pem"
```

## Description

Add missing entrypoints to setup.py

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)